### PR TITLE
Parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,13 +3,27 @@ name = "grace"
 version = "0.1.0"
 dependencies = [
  "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
 version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "log"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "memchr"
@@ -28,6 +42,8 @@ dependencies = [
 ]
 
 [metadata]
+"checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "5ba3df4dcb460b9dfbd070d41c94c19209620c191b0340b929ce748a2bcd42d2"
+"checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 "checksum nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05aec50c70fd288702bcd93284a8444607f3292dbdf2a30de5ea5dcdbe72287b"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,4 +1,9 @@
-[root]
+[[package]]
+name = "cfg-if"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "grace"
 version = "0.1.0"
 dependencies = [
@@ -6,11 +11,6 @@ dependencies = [
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ authors = ["Vincent Luczkow <vincent.luczkow@gmail.com>",
 [dependencies]
 nom = "~3"
 libc = "*"
+log = "0.4"

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -52,14 +52,17 @@ impl ASTNode for Identifier {
 pub struct IfStatement {
     pub condition: Box<Expression>,
     pub main_block: Box<Block>,
-    pub elifs: Option<Vec<(Box<Expression>, Box<Block>)>>,
+    pub elifs: Vec<(Box<Expression>, Box<Block>)>,
     pub else_block: Option<Box<Block>>
 }
 
 impl Display for IfStatement {
-
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "If statement.\n  Condition: {}.\n  Block: {}", self.condition, self.main_block)
+        let elifs_iter = self.elifs.iter();
+        let mapped =
+            elifs_iter.map( |x| (*x).1.to_string());
+        let strings = mapped.collect::<Vec<String>>().join("\n");
+        write!(f, "If statement.\n  Condition: {}.\n  Block: {}\n  elifs: {}", self.condition, self.main_block, strings)
     }
 }
 impl ASTNode for IfStatement {

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -113,7 +113,7 @@ pub struct Assignment{
 
 impl Display for Assignment{
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{} = {}", self.identifier, self.expression.to_string())
+        write!(f, "Assignment: {} = {}", self.identifier, self.expression.to_string())
     }
 }
 impl ASTNode for Assignment{

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -56,13 +56,25 @@ pub struct IfStatement {
     pub else_block: Option<Box<Block>>
 }
 
+// TODO: Prettier printing.
 impl Display for IfStatement {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let elifs_iter = self.elifs.iter();
         let mapped =
             elifs_iter.map( |x| (*x).1.to_string());
         let strings = mapped.collect::<Vec<String>>().join("\n");
-        write!(f, "If statement.\n  Condition: {}.\n  Block: {}\n  elifs: {}", self.condition, self.main_block, strings)
+
+        let else_string = match self.else_block {
+            Some(ref x) => {
+                (*x).to_string()
+            },
+            None => {
+                println!("Else is none");
+                "".to_string()
+            }
+        };
+
+        write!(f, "If statement.\n  Condition: {}.\n  Block: {}elifs: {}else: {}", self.condition, self.main_block, strings, else_string)
     }
 }
 impl ASTNode for IfStatement {

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -49,6 +49,27 @@ impl ASTNode for Identifier {
     }
 }
 
+pub struct FunctionDec {
+    pub name: Identifier,
+    pub args: Vec<Identifier>,
+    pub body: Box<Block>
+}
+
+impl Display for FunctionDec {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Function declaration.")
+    }
+}
+
+impl ASTNode for FunctionDec {
+ fn subtree_as_string(&self) -> &str {
+        panic!()
+    }
+}
+
+impl Statement for FunctionDec {}
+
+
 pub struct IfStatement {
     pub condition: Box<Expression>,
     pub main_block: Box<Block>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
-#[macro_use]
+//#[macro_use]
 //extern crate nom;
+
+#[macro_use]
+extern crate log;
 
 //pub mod error;
 //pub mod parser;

--- a/test_data/simple_grace.gr
+++ b/test_data/simple_grace.gr
@@ -1,6 +1,17 @@
 foo = false and false and true and true
+
+
+
+
 bar = true and false
+
+
+
+
 if true and true:
     foo = true and false
+
+
+
 elif false and false:
     bar = false and true

--- a/test_data/simple_grace.gr
+++ b/test_data/simple_grace.gr
@@ -30,4 +30,9 @@ else:
     foobar = true and true
 
 
-foo = true
+
+test = true
+
+
+
+

--- a/test_data/simple_grace.gr
+++ b/test_data/simple_grace.gr
@@ -2,3 +2,5 @@ foo = false and false and true and true
 bar = true and false
 if true and true:
     foo = true and false
+elif false and false:
+    bar = false and true

--- a/test_data/simple_grace.gr
+++ b/test_data/simple_grace.gr
@@ -1,7 +1,6 @@
 foo = false and false and true and true
 
-
-
+test = false
 
 bar = true and false
 
@@ -9,9 +8,23 @@ bar = true and false
 
 
 if true and true:
+
     foo = true and false
 
 
 
-elif false and false:
+elif false:
+
+    test2 = true
+
+
+
+
+
     bar = false and true
+
+
+else:
+
+
+    foobar = true and true

--- a/test_data/simple_grace.gr
+++ b/test_data/simple_grace.gr
@@ -28,3 +28,6 @@ else:
 
 
     foobar = true and true
+
+
+foo = true


### PR DESCRIPTION
Blocks can deal with empty lines between statements now, although they still have to start with a statement.